### PR TITLE
MySQL Data Storage Commenced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /EDI/build/
 /JDBC_MySQL/build/
 /JDBC_MySQL/nbproject/private/
+/dist/

--- a/EDI/src/com/is2300/jedi/edi/utils/Utils.java
+++ b/EDI/src/com/is2300/jedi/edi/utils/Utils.java
@@ -106,4 +106,84 @@ public class Utils {
         // Return our return value.
         return retVal;
     }
+    
+    /**
+     * <tt>string2Date(String date, String time)</tt> returns a <tt>
+     * <a href="http://docs.oracle.com/javase/8/docs/api/java/util/Date.html">
+     * java.util.Date</a></tt> object that can then be used as is or to create
+     * other objects for use, such as a <tt>
+     * <a href="http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html">
+     * java.util.Calendar</a></tt> object.
+     * 
+     * @param date the <tt>java.lang.String</tt> that needs to be converted to a
+     *             <tt>java.util.Date</tt> object. The string needs to be 
+     *             formatted as either:
+     *              <ul><li>YYMMDD</li>
+     *                  <li>YYYYMMDD</li></ul>
+     *             If the string is formatted in any other manner, an invalid
+     *             date will be returned. <em>It is good practice to validate
+     *             the returned <tt>java.util.Date</tt> object before using it
+     *             </em>
+     * @param time the <tt>java.lang.String</tt> that needs to be converted to a
+     *              <tt>java.util.Date</tt> object. The string needs to be 
+     *              formatted as either:
+     *              <ul><li>HHMM</li>
+     *                  <li>HHMMSS</li></ul>
+     *              If the string is formatted in any other manner, an invalid
+     *              date will be returned. <em>It is good practice to validate
+     *              the returned <tt>java.util.Date</tt> object before using it
+     *              </em>
+     * @return <tt>java.util.Date</tt> object initialized to the date string
+     *          that was provided.
+     */
+    public static Date string2Date(String date, String time) {
+        // Declare three strings to hold the month, day and year once we parse
+        //+ them out of the date string that is provided.
+        Integer day = null;
+        Integer month = null;
+        Integer year = null;
+        
+        // Declare three strings to hold the house, minutes and seconds once we
+        //+ parse them out of the time string that is provided.
+        Integer hours = null;
+        Integer minutes = null;
+        Integer seconds = null;
+        
+        // Now, check the length of the date string.
+        if ( date.length() == 6 ) {
+            // The format of the string is YYMMDD, so we need to parse those
+            //+ individual fields out of the string.
+            year = new Integer(date.substring(0, 2));
+            month = new Integer(date.substring(2, 4));
+            day = new Integer(date.substring(4, 6));
+
+        } else if ( date.length() == 8 ) {
+            // The format of the string is YYYYMMDD, so we need to parse those
+            //+ individual fields out of the string.
+            year = new Integer(date.substring(0, 4));
+            month = new Integer(date.substring(4, 6));
+            day = new Integer(date.substring(6, 8));
+            
+        }
+        
+        // Next, we need to deal with the time. So, we need to check its length.
+        if ( time.length() == 4 ) {
+            // The format of the string is HHMM, so we need to parse those
+            //+ individual fields out of the string.
+            hours = new Integer(time.substring(0, 2));
+            minutes = new Integer(time.substring(2, 4));
+            seconds = 0;
+            
+        } else if ( time.length() == 6 ) {
+            // The format of the string is HHMMSS, so we need to parse those
+            //+ individual fields out of the string.
+            hours = new Integer(time.substring(0, 2));
+            minutes = new Integer(time.substring(2, 4));
+            seconds = new Integer(time.substring(4, 6));
+            
+        }
+        
+        // Return our new Date object.
+        return new Date(year, month, day, hours, minutes, seconds);
+    }
 }


### PR DESCRIPTION
Started working on storing data from the incoming EDI transmission file to the MySQL database, is_jedi, and putting information into the audit tables.

Have one issue in the code being committed at this time: date math is not taking place as one would expect. I'm displaying information during the processing cycle to the Output window of the Platform and showing a summary report at the end of the output that looks like this:

     Sat: 03/11/2017 - 09:46:21: Initializing EDI processor...
     ...
     Sat: 03/11/2017 - 09:46:31:  Parsing Complete.
	    Envelopes:  61
	       Groups:  61
     Transactions:  124
     Processed in 0.000000 minute(s)

As you can see in the above example, the date math is not correct for how long the processing took. The process took a total of ten (10) or so seconds, but the date math shows "0.000000" for the processing time.
I am unable, so far, to figure out why this is. I've gone from using the `java.util.Calendar.compare()` method to doing the math by hand by extracting the start and end time milliseconds by using the `java.util.Calendar.getTimeInMillis()` function, then subtracting, and then doing the division. However, no matter how I do this, the result is the same: 0.000000. I've used both a `float` and a `double` for performing the division into and both come out the same.

If anyone has any ideas on this, please comment on this commit and let me know. We have got to solve this weird issue before we get to a release, otherwise, we need to drop the date math portion of the  process summary, which I really don't want to do.

***Just a note:** I have posted this issue to a Java mailing list, so hopefully, we'll get some help that way. Also, there are comments below the block of code in question in:
`com.is2300.jedi.edi.Processor.selfDestruct()`*